### PR TITLE
A* Fixes

### DIFF
--- a/src/main/java/edu/wpi/teame/map/pathfinding/AStarPathfinder.java
+++ b/src/main/java/edu/wpi/teame/map/pathfinding/AStarPathfinder.java
@@ -63,10 +63,11 @@ public class AStarPathfinder extends AbstractPathfinder {
 
   int heuristicDistance(HospitalNode from, HospitalNode to) {
     // estimate the distance to the target based on the euclidean distance to the target
+    int floorBias = 5;
     return (int)
-        Math.sqrt(
-            Math.pow(from.getXCoord() - to.getXCoord(), 2)
-                + Math.pow(from.getYCoord() - to.getYCoord(), 2));
+        Math.sqrt( Math.pow(from.getXCoord() - to.getXCoord(), 2)
+                + Math.pow(from.getYCoord() - to.getYCoord(), 2))
+            + (int) floorBias*Math.abs(from.getFloor().ordinal() - to.getFloor().ordinal());
   }
 
   /**

--- a/src/main/java/edu/wpi/teame/map/pathfinding/AStarPathfinder.java
+++ b/src/main/java/edu/wpi/teame/map/pathfinding/AStarPathfinder.java
@@ -24,6 +24,7 @@ public class AStarPathfinder extends AbstractPathfinder {
             new Comparator<HospitalNode>() {
               @Override
               public int compare(HospitalNode o1, HospitalNode o2) {
+                int costBias = 25;
                 // Based on heuristic distance to target
                 return (costMap.get(o1) + heuristicDistance(o1, to))
                     - (costMap.get(o2) + heuristicDistance(o2, to));
@@ -63,11 +64,11 @@ public class AStarPathfinder extends AbstractPathfinder {
 
   int heuristicDistance(HospitalNode from, HospitalNode to) {
     // estimate the distance to the target based on the euclidean distance to the target
-    int floorBias = 5;
+    int floorBias = 150;
     return (int)
         Math.sqrt( Math.pow(from.getXCoord() - to.getXCoord(), 2)
                 + Math.pow(from.getYCoord() - to.getYCoord(), 2))
-            + (int) floorBias*Math.abs(from.getFloor().ordinal() - to.getFloor().ordinal());
+            + (int) floorBias * Math.abs(from.getFloor().ordinal() - to.getFloor().ordinal());
   }
 
   /**


### PR DESCRIPTION
Previously, there were two problems with our implementation of the A* pathfinding algorithm.

The first problem is that the heuristic distance approximation did not account for the difference in floors when prioritizing the queue of nodes to check. That has been fixed, with a scaling factor that is equivalent to 6 edges. This can be tuned later but seemed to be fine for now.

The second problem was that the cost weight of the edges were not using an equivalent (or even similar) units to the heuristic. The heuristic uses (x,y) coordinates that are in the 3-4 digit range, and edge weights prior to this update were just 1 per node. I've added a scaling factor for edge weights, currently setting the weight of 1 edge to be equal to 25 coordinate units (not sure what that is measured in either tbh). Before this change was implemented, our A* algorithm was acting more like a Greedy-breadth-first-search algorithm, so now our algorithm should actually behave like A*